### PR TITLE
Keep alive values not supported

### DIFF
--- a/src/Zyborg.Logentries/LogentriesClient.cs
+++ b/src/Zyborg.Logentries/LogentriesClient.cs
@@ -102,9 +102,16 @@ namespace Zyborg.Logentries
             // so data should be sent immediately. And indeed it does appear to be sent promptly when it works.
             m_Client.Client.SetSocketOption( SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
 
-            // set timeouts to 10 seconds idle before keepalive, 1 second between repeats, 
-            SetSocketKeepAliveValues(m_Client, 10 *1000, 1000);
-            
+            // set timeouts to 10 seconds idle before keepalive, 1 second between repeats,
+            try
+            {
+                SetSocketKeepAliveValues(m_Client, 10 * 1000, 1000);
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // .net core on linux does not support chaning of that settings at the moment. defaults applied.
+            }
+
             m_Stream = m_Client.GetStream();
 
             if (m_UseSsl)

--- a/src/Zyborg.Logentries/LogentriesClient.cs
+++ b/src/Zyborg.Logentries/LogentriesClient.cs
@@ -109,7 +109,7 @@ namespace Zyborg.Logentries
             }
             catch (PlatformNotSupportedException)
             {
-                // .net core on linux does not support chaning of that settings at the moment. defaults applied.
+                // .net core on linux does not support modification of that settings at the moment. defaults applied.
             }
 
             m_Stream = m_Client.GetStream();


### PR DESCRIPTION
Current version of .net core 1.1 does not support low-level optimizations/adjustments for the sockets (see error below). As far as keep-alive still enabled for socket with default values I propose just ignore PlatformNotSupportedException for the current moment (added comment explaining the reason). 

```
System.IO.IOException: An error occurred while opening the connection. ---> System.PlatformNotSupportedException: Operation is not supported on this platform.
   at System.Net.Sockets.SocketPal.WindowsIoctl(SafeCloseSocket handle, Int32 ioControlCode, Byte[] optionInValue, Byte[] optionOutValue, Int32& optionLength)
   at System.Net.Sockets.Socket.IOControl(Int32 ioControlCode, Byte[] optionInValue, Byte[] optionOutValue)
   at System.Net.Sockets.Socket.IOControl(IOControlCode ioControlCode, Byte[] optionInValue, Byte[] optionOutValue)
   at Zyborg.Logentries.LogentriesClient.SetSocketKeepAliveValues(TcpClient tcpc, Int32 KeepAliveTime, Int32 KeepAliveInterval) in /src/Zyborg.Logentries/LogentriesClient.cs:line 88
```
